### PR TITLE
Specify the package-name in CI, so testing only runs on that package

### DIFF
--- a/.github/workflows/build_and_test_humble.yaml
+++ b/.github/workflows/build_and_test_humble.yaml
@@ -2,7 +2,7 @@
 
 name: Build and Test (humble)
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push
   push:
@@ -34,3 +34,4 @@ jobs:
         with:
           target-ros2-distro: humble
           vcs-repo-file-url: dependencies.repos
+          package-name: soccer_ipm

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -34,3 +34,4 @@ jobs:
         with:
           target-ros2-distro: rolling
           vcs-repo-file-url: dependencies.repos
+          package-name: soccer_ipm


### PR DESCRIPTION
By specifying the package name, it will build all packages-up-to soccer_ipm, and test only soccer_ipm.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>