### PR TITLE
Add missing exception handeling

### DIFF
--- a/soccer_ipm/soccer_ipm/msgs/ball.py
+++ b/soccer_ipm/soccer_ipm/msgs/ball.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ipm_library.exceptions import CameraInfoNotSetException, NoIntersectionError
+from ipm_library.exceptions import NoIntersectionError
 from ipm_library.ipm import IPM
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from soccer_ipm.utils import create_horizontal_plane
@@ -60,7 +60,4 @@ def map_ball_array(
             logger.warn(
                 f'Could not transform ball at ({ball.center.x},{ball.center.y}).',
                 throttle_duration_sec=5)
-        except CameraInfoNotSetException:
-            logger.warn('Inverse perspective mapping should be performed, \
-                but no camera info was recived yet!', throttle_duration_sec=5)
     return balls_relative

--- a/soccer_ipm/soccer_ipm/msgs/field_boundary.py
+++ b/soccer_ipm/soccer_ipm/msgs/field_boundary.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from geometry_msgs.msg import Point
-from ipm_library.exceptions import CameraInfoNotSetException
 from ipm_library.ipm import IPM
 import numpy as np
 from rclpy.impl.rcutils_logger import RcutilsLogger
@@ -47,16 +46,12 @@ def map_field_boundary(
     points_np = np.array([[p.x, p.y] for p in msg.points])
 
     # Map all points at once from image onto field plane
-    try:
-        points_on_plane = ipm.map_points(
-            field,
-            points_np,
-            msg.header.stamp,
-            plane_frame_id=output_frame,
-            output_frame_id=output_frame)[1]
-    except CameraInfoNotSetException:
-        logger.warn('Inverse perspective mapping should be performed, \
-                but no camera info was recived yet!', throttle_duration_sec=5)
+    points_on_plane = ipm.map_points(
+        field,
+        points_np,
+        msg.header.stamp,
+        plane_frame_id=output_frame,
+        output_frame_id=output_frame)[1]
 
     # Check for invalid field boundary points and convert back from numpy
     for p in points_on_plane:

--- a/soccer_ipm/soccer_ipm/msgs/field_boundary.py
+++ b/soccer_ipm/soccer_ipm/msgs/field_boundary.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from geometry_msgs.msg import Point
+from ipm_library.exceptions import CameraInfoNotSetException
 from ipm_library.ipm import IPM
 import numpy as np
 from rclpy.impl.rcutils_logger import RcutilsLogger
@@ -46,12 +47,16 @@ def map_field_boundary(
     points_np = np.array([[p.x, p.y] for p in msg.points])
 
     # Map all points at once from image onto field plane
-    points_on_plane = ipm.map_points(
-        field,
-        points_np,
-        msg.header.stamp,
-        plane_frame_id=output_frame,
-        output_frame_id=output_frame)[1]
+    try:
+        points_on_plane = ipm.map_points(
+            field,
+            points_np,
+            msg.header.stamp,
+            plane_frame_id=output_frame,
+            output_frame_id=output_frame)[1]
+    except CameraInfoNotSetException:
+        logger.warn('Inverse perspective mapping should be performed, \
+                but no camera info was recived yet!', throttle_duration_sec=5)
 
     # Check for invalid field boundary points and convert back from numpy
     for p in points_on_plane:

--- a/soccer_ipm/soccer_ipm/msgs/goalpost.py
+++ b/soccer_ipm/soccer_ipm/msgs/goalpost.py
@@ -14,7 +14,7 @@
 
 from typing import Tuple
 
-from ipm_library.exceptions import CameraInfoNotSetException, NoIntersectionError
+from ipm_library.exceptions import NoIntersectionError
 from ipm_library.ipm import IPM
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from soccer_ipm.utils import (bb_footpoint, create_horizontal_plane, object_at_bottom_of_image)
@@ -81,7 +81,4 @@ def map_goalpost_array(
                         footpoint.x,
                         footpoint.y),
                     throttle_duration_sec=5)
-            except CameraInfoNotSetException:
-                logger.warn('Inverse perspective mapping should be performed, \
-                    but no camera info was recived yet!', throttle_duration_sec=5)
     return goalposts_relative_msg

--- a/soccer_ipm/soccer_ipm/msgs/markings.py
+++ b/soccer_ipm/soccer_ipm/msgs/markings.py
@@ -157,12 +157,16 @@ def map_marking_segments(
         (segment.end.x, segment.end.y)) for segment in marking_segments_2d])
 
     # Map all points at once from image onto field plane
-    segments_on_plane = ipm.map_points(
-        field,
-        segment_points_np.reshape(-1, 2),
-        header.stamp,
-        plane_frame_id=output_frame,
-        output_frame_id=output_frame)[1].reshape(-1, 2, 3)
+    try:
+        segments_on_plane = ipm.map_points(
+            field,
+            segment_points_np.reshape(-1, 2),
+            header.stamp,
+            plane_frame_id=output_frame,
+            output_frame_id=output_frame)[1].reshape(-1, 2, 3)
+    except CameraInfoNotSetException:
+        logger.warn('Inverse perspective mapping should be performed, \
+                but no camera info was recived yet!', throttle_duration_sec=5)
 
     # Convert the numpy array back to the soccer vision messages datatype
     marking_segments_3d = []

--- a/soccer_ipm/soccer_ipm/msgs/markings.py
+++ b/soccer_ipm/soccer_ipm/msgs/markings.py
@@ -15,7 +15,7 @@
 from typing import List
 
 from geometry_msgs.msg import Vector3
-from ipm_library.exceptions import CameraInfoNotSetException, NoIntersectionError
+from ipm_library.exceptions import NoIntersectionError
 from ipm_library.ipm import IPM
 import numpy as np
 from rclpy.impl.rcutils_logger import RcutilsLogger
@@ -127,9 +127,6 @@ def map_marking_intersections(
                     mapped_center_point.point.x,
                     mapped_center_point.point.y),
                 throttle_duration_sec=5)
-        except CameraInfoNotSetException:
-            logger.warn('Inverse perspective mapping should be performed, \
-                but no camera info was recived yet!', throttle_duration_sec=5)
     return intersections_3d
 
 
@@ -157,16 +154,12 @@ def map_marking_segments(
         (segment.end.x, segment.end.y)) for segment in marking_segments_2d])
 
     # Map all points at once from image onto field plane
-    try:
-        segments_on_plane = ipm.map_points(
-            field,
-            segment_points_np.reshape(-1, 2),
-            header.stamp,
-            plane_frame_id=output_frame,
-            output_frame_id=output_frame)[1].reshape(-1, 2, 3)
-    except CameraInfoNotSetException:
-        logger.warn('Inverse perspective mapping should be performed, \
-                but no camera info was recived yet!', throttle_duration_sec=5)
+    segments_on_plane = ipm.map_points(
+        field,
+        segment_points_np.reshape(-1, 2),
+        header.stamp,
+        plane_frame_id=output_frame,
+        output_frame_id=output_frame)[1].reshape(-1, 2, 3)
 
     # Convert the numpy array back to the soccer vision messages datatype
     marking_segments_3d = []
@@ -252,7 +245,4 @@ def map_marking_ellipses(
                     ellipse.center.x,
                     ellipse.center.x),
                 throttle_duration_sec=5)
-        except CameraInfoNotSetException:
-            logger.warn('Inverse perspective mapping should be performed, \
-                but no camera info was recived yet!', throttle_duration_sec=5)
     return ellipses_3d

--- a/soccer_ipm/soccer_ipm/msgs/obstacles.py
+++ b/soccer_ipm/soccer_ipm/msgs/obstacles.py
@@ -14,7 +14,7 @@
 
 from typing import Tuple
 
-from ipm_library.exceptions import CameraInfoNotSetException, NoIntersectionError
+from ipm_library.exceptions import NoIntersectionError
 from ipm_library.ipm import IPM
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from soccer_ipm.utils import (bb_footpoint, create_horizontal_plane, object_at_bottom_of_image)
@@ -78,7 +78,4 @@ def map_obstacle_array(
                         footpoint.x,
                         footpoint.y),
                     throttle_duration_sec=5)
-            except CameraInfoNotSetException:
-                logger.warn('Inverse perspective mapping should be performed, \
-                    but no camera info was recived yet!', throttle_duration_sec=5)
     return obstacles

--- a/soccer_ipm/soccer_ipm/msgs/robots.py
+++ b/soccer_ipm/soccer_ipm/msgs/robots.py
@@ -14,7 +14,7 @@
 
 from typing import Tuple
 
-from ipm_library.exceptions import CameraInfoNotSetException, NoIntersectionError
+from ipm_library.exceptions import NoIntersectionError
 from ipm_library.ipm import IPM
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from soccer_ipm.utils import (bb_footpoint, create_horizontal_plane, object_at_bottom_of_image)
@@ -80,7 +80,4 @@ def map_robot_array(
                         footpoint.x,
                         footpoint.y),
                     throttle_duration_sec=5)
-            except CameraInfoNotSetException:
-                logger.warn('Inverse perspective mapping should be performed, \
-                    but no camera info was recived yet!', throttle_duration_sec=5)
     return robots

--- a/soccer_ipm/soccer_ipm/soccer_ipm.py
+++ b/soccer_ipm/soccer_ipm/soccer_ipm.py
@@ -24,6 +24,7 @@ from soccer_ipm.msgs.goalpost import map_goalpost_array
 from soccer_ipm.msgs.markings import map_marking_array
 from soccer_ipm.msgs.obstacles import map_obstacle_array
 from soccer_ipm.msgs.robots import map_robot_array
+from soccer_ipm.utils import catch_camera_info_error
 import soccer_vision_2d_msgs.msg as sv2dm
 import soccer_vision_3d_msgs.msg as sv3dm
 import tf2_ros as tf2
@@ -64,6 +65,7 @@ class SoccerIPM(Node):
         # Balls
         ball_publisher = self.create_publisher(sv3dm.BallArray, 'balls_relative', 1)
 
+        @catch_camera_info_error(self.get_logger())
         def ball_sub(msg):
             ball_publisher.publish(
                 map_ball_array(
@@ -84,6 +86,7 @@ class SoccerIPM(Node):
         # Goal posts
         goalpost_publisher = self.create_publisher(sv3dm.GoalpostArray, 'goal_posts_relative', 1)
 
+        @catch_camera_info_error(self.get_logger())
         def goalpost_pub(msg):
             goalpost_publisher.publish(
                 map_goalpost_array(
@@ -110,6 +113,7 @@ class SoccerIPM(Node):
         # Robots
         robot_publisher = self.create_publisher(sv3dm.RobotArray, 'robots_relative', 1)
 
+        @catch_camera_info_error(self.get_logger())
         def robot_sub(msg):
             robot_publisher.publish(
                 map_robot_array(
@@ -136,6 +140,7 @@ class SoccerIPM(Node):
         # Obstacles
         obstacle_publisher = self.create_publisher(sv3dm.ObstacleArray, 'obstacles_relative', 1)
 
+        @catch_camera_info_error(self.get_logger())
         def obstacle_sub(msg):
             obstacle_publisher.publish(
                 map_obstacle_array(
@@ -165,6 +170,7 @@ class SoccerIPM(Node):
             'field_boundary_relative',
             1)
 
+        @catch_camera_info_error(self.get_logger())
         def field_boundary_sub(msg):
             field_boundary_publisher.publish(
                 map_field_boundary(
@@ -184,6 +190,7 @@ class SoccerIPM(Node):
         # Markings
         markings_publisher = self.create_publisher(sv3dm.MarkingArray, 'markings_relative', 1)
 
+        @catch_camera_info_error(self.get_logger())
         def markings_sub(msg):
             markings_publisher.publish(
                 map_marking_array(

--- a/soccer_ipm/soccer_ipm/soccer_ipm.py
+++ b/soccer_ipm/soccer_ipm/soccer_ipm.py
@@ -24,7 +24,7 @@ from soccer_ipm.msgs.goalpost import map_goalpost_array
 from soccer_ipm.msgs.markings import map_marking_array
 from soccer_ipm.msgs.obstacles import map_obstacle_array
 from soccer_ipm.msgs.robots import map_robot_array
-from soccer_ipm.utils import catch_camera_info_error
+from soccer_ipm.utils import catch_camera_info_not_set_error
 import soccer_vision_2d_msgs.msg as sv2dm
 import soccer_vision_3d_msgs.msg as sv3dm
 import tf2_ros as tf2
@@ -65,7 +65,7 @@ class SoccerIPM(Node):
         # Balls
         ball_publisher = self.create_publisher(sv3dm.BallArray, 'balls_relative', 1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def ball_sub(msg):
             ball_publisher.publish(
                 map_ball_array(
@@ -86,7 +86,7 @@ class SoccerIPM(Node):
         # Goal posts
         goalpost_publisher = self.create_publisher(sv3dm.GoalpostArray, 'goal_posts_relative', 1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def goalpost_pub(msg):
             goalpost_publisher.publish(
                 map_goalpost_array(
@@ -113,7 +113,7 @@ class SoccerIPM(Node):
         # Robots
         robot_publisher = self.create_publisher(sv3dm.RobotArray, 'robots_relative', 1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def robot_sub(msg):
             robot_publisher.publish(
                 map_robot_array(
@@ -140,7 +140,7 @@ class SoccerIPM(Node):
         # Obstacles
         obstacle_publisher = self.create_publisher(sv3dm.ObstacleArray, 'obstacles_relative', 1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def obstacle_sub(msg):
             obstacle_publisher.publish(
                 map_obstacle_array(
@@ -170,7 +170,7 @@ class SoccerIPM(Node):
             'field_boundary_relative',
             1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def field_boundary_sub(msg):
             field_boundary_publisher.publish(
                 map_field_boundary(
@@ -190,7 +190,7 @@ class SoccerIPM(Node):
         # Markings
         markings_publisher = self.create_publisher(sv3dm.MarkingArray, 'markings_relative', 1)
 
-        @catch_camera_info_error(self.get_logger())
+        @catch_camera_info_not_set_error(self.get_logger())
         def markings_sub(msg):
             markings_publisher.publish(
                 map_marking_array(

--- a/soccer_ipm/soccer_ipm/utils.py
+++ b/soccer_ipm/soccer_ipm/utils.py
@@ -63,7 +63,7 @@ def bb_footpoint(bounding_box: BoundingBox2D) -> Point2D:
     )
 
 
-def catch_camera_info_error(logger: RcutilsLogger) -> Callable:
+def catch_camera_info_not_set_error(logger: RcutilsLogger) -> Callable:
     """
     Camera info exception handling decorator factory.
 

--- a/soccer_ipm/soccer_ipm/utils.py
+++ b/soccer_ipm/soccer_ipm/utils.py
@@ -78,7 +78,9 @@ def catch_camera_info_error(logger: RcutilsLogger) -> Callable:
             try:
                 return f(*args, **kwargs)
             except CameraInfoNotSetException:
-                logger.warn('Inverse perspective mapping should be performed, ' +
-                            'but no camera info was recived yet!', throttle_duration_sec=5)
+                logger.warn(
+                    'Inverse perspective mapping should be performed, '
+                    'but no camera info was recived yet!',
+                    throttle_duration_sec=5)
         return wrapper
     return wrapped_decorator


### PR DESCRIPTION
The case that a message is received before the first camera info, is only handled for message types that use `project_point` and not for ones that use `project_points`. This pull request adds this functionality.