### PR TITLE
Fix installation of message folder

### DIFF
--- a/soccer_ipm/setup.py
+++ b/soccer_ipm/setup.py
@@ -1,5 +1,6 @@
 import glob
 
+from setuptools import find_packages
 from setuptools import setup
 
 package_name = 'soccer_ipm'
@@ -7,7 +8,7 @@ package_name = 'soccer_ipm'
 setup(
     name=package_name,
     version='0.0.0',
-    packages=[package_name],
+    packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
Currently, the `msgs` folder is not correctly installed when `--symlink-install` is not used with `colcon`.
Files installed with the current `rolling` branch:
```
➜  colcon_ws tree install/soccer_ipm/lib/python3/dist-packages/soccer_ipm
install/soccer_ipm/lib/python3/dist-packages/soccer_ipm
├── __init__.py
├── __pycache__
│   ├── __init__.cpython-310.pyc
│   ├── soccer_ipm.cpython-310.pyc
│   └── utils.cpython-310.pyc
├── soccer_ipm.py
└── utils.py
```
Files installed with this patch applied:
```
➜  colcon_ws tree install/soccer_ipm/lib/python3/dist-packages/soccer_ipm
install/soccer_ipm/lib/python3/dist-packages/soccer_ipm
├── __init__.py
├── msgs
│   ├── ball.py
│   ├── field_boundary.py
│   ├── goalpost.py
│   ├── __init__.py
│   ├── markings.py
│   ├── obstacles.py
│   ├── __pycache__
│   │   ├── ball.cpython-310.pyc
│   │   ├── field_boundary.cpython-310.pyc
│   │   ├── goalpost.cpython-310.pyc
│   │   ├── __init__.cpython-310.pyc
│   │   ├── markings.cpython-310.pyc
│   │   ├── obstacles.cpython-310.pyc
│   │   └── robots.cpython-310.pyc
│   └── robots.py
├── __pycache__
│   ├── __init__.cpython-310.pyc
│   ├── soccer_ipm.cpython-310.pyc
│   └── utils.cpython-310.pyc
├── soccer_ipm.py
└── utils.py
```

~Also I'm not really sure how the CI works for the ros-sports repositories but I feel like it should have caught that.~
I see this is the default ROS CI and it only tests with `--symlink-install`.
