### PR TITLE
Catch tf errors

### DIFF
--- a/soccer_ipm/soccer_ipm/soccer_ipm.py
+++ b/soccer_ipm/soccer_ipm/soccer_ipm.py
@@ -24,7 +24,7 @@ from soccer_ipm.msgs.goalpost import map_goalpost_array
 from soccer_ipm.msgs.markings import map_marking_array
 from soccer_ipm.msgs.obstacles import map_obstacle_array
 from soccer_ipm.msgs.robots import map_robot_array
-from soccer_ipm.utils import catch_camera_info_not_set_error
+from soccer_ipm.utils import catch_camera_info_not_set_error, catch_tf_timing_error
 import soccer_vision_2d_msgs.msg as sv2dm
 import soccer_vision_3d_msgs.msg as sv3dm
 import tf2_ros as tf2
@@ -66,6 +66,7 @@ class SoccerIPM(Node):
         ball_publisher = self.create_publisher(sv3dm.BallArray, 'balls_relative', 1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def ball_sub(msg):
             ball_publisher.publish(
                 map_ball_array(
@@ -87,6 +88,7 @@ class SoccerIPM(Node):
         goalpost_publisher = self.create_publisher(sv3dm.GoalpostArray, 'goal_posts_relative', 1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def goalpost_pub(msg):
             goalpost_publisher.publish(
                 map_goalpost_array(
@@ -114,6 +116,7 @@ class SoccerIPM(Node):
         robot_publisher = self.create_publisher(sv3dm.RobotArray, 'robots_relative', 1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def robot_sub(msg):
             robot_publisher.publish(
                 map_robot_array(
@@ -141,6 +144,7 @@ class SoccerIPM(Node):
         obstacle_publisher = self.create_publisher(sv3dm.ObstacleArray, 'obstacles_relative', 1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def obstacle_sub(msg):
             obstacle_publisher.publish(
                 map_obstacle_array(
@@ -171,6 +175,7 @@ class SoccerIPM(Node):
             1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def field_boundary_sub(msg):
             field_boundary_publisher.publish(
                 map_field_boundary(
@@ -191,6 +196,7 @@ class SoccerIPM(Node):
         markings_publisher = self.create_publisher(sv3dm.MarkingArray, 'markings_relative', 1)
 
         @catch_camera_info_not_set_error(self.get_logger())
+        @catch_tf_timing_error(self.get_logger())
         def markings_sub(msg):
             markings_publisher.publish(
                 map_marking_array(

--- a/soccer_ipm/soccer_ipm/utils.py
+++ b/soccer_ipm/soccer_ipm/utils.py
@@ -89,7 +89,7 @@ def catch_camera_info_not_set_error(logger: RcutilsLogger) -> Callable:
 
 def catch_tf_timing_error(logger: RcutilsLogger) -> Callable:
     """
-    Camera info exception handling decorator factory.
+    TF exception handling decorator factory.
 
     See also https://www.artima.com/weblogs/viewpost.jsp?thread=240845
 


### PR DESCRIPTION
Currently, the soccer IPM dies if a tf error occurs. The PR adds a decorator which handles it.