### PR TITLE
Fix shutdown of soccer_ipm

### DIFF
--- a/soccer_ipm/soccer_ipm/soccer_ipm.py
+++ b/soccer_ipm/soccer_ipm/soccer_ipm.py
@@ -219,6 +219,8 @@ def main(args=None):
     node = SoccerIPM()
     ex = MultiThreadedExecutor(num_threads=4)
     ex.add_node(node)
-    ex.spin()
+    try:
+        ex.spin()
+    except KeyboardInterrupt:
+        pass
     node.destroy_node()
-    rclpy.shutdown()


### PR DESCRIPTION
When a the software is interrupted, a `KeyboardInterrupt` is raised in `ex.spin()`. This should be excepted instead of being raised to the user and the node should be destroyed. `rclpy.shutdown()` should not be called because the keyboard interrupt already does the shutdown. (If we don't remove it, we get the error `failed to shutdown: rcl_shutdown already called on the given context`).